### PR TITLE
Add create and deploy workflows

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,63 @@
+name: Create Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Choose the version bump type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+jobs:
+  create_release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Set Git user identity (repository-scoped)
+        run: |
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions Bot"
+
+      - name: Check if 'release' branch exists
+        run: |
+          if git show-ref --verify --quiet refs/heads/release; then
+            echo "Release branch already exists, exiting."
+            exit 1
+          fi
+
+      - name: Create and switch to release branch
+        run: |
+          git checkout -b release
+          git push origin release
+
+      - name: Bump version
+        run: |
+          version_type="${{ github.event.inputs.version }}"
+          echo "Bumping version by: $version_type"
+          bump2version $version_type
+          git push --follow-tags
+
+      - name: Raise Pull Request
+        uses: repo-sync/pull-request-action@v2
+        with:
+          source_branch: release
+          target_branch: main
+          pr_title: "Release Version"
+          pr_body: "This PR includes the bumped version and tag."
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -1,0 +1,42 @@
+name: Deploy Release
+
+on:
+  pull_request:
+    types: [closed]  # Trigger when the PR is closed (merged or closed without merging)
+    branches:
+      - main
+    # Make sure the source branch is 'release'
+    if: github.event.pull_request.head.ref == 'release'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  deploy_release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+
+      - name: Install PIP Requirements
+        run: |
+          pip install twine
+
+      - name: Build the package
+        run: |
+          poetry build
+
+      - name: Publish to PyPI
+        run: |
+          twine upload dist/* -u __token__ -p ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Splitting out stages of publish workflow to work around limitation of github actions bot pushing to protected branch

This allows a user to manually run create action to raise a PR that will automagically deploy a release once merged